### PR TITLE
documentation clean-up

### DIFF
--- a/doc/howto/cli.rst
+++ b/doc/howto/cli.rst
@@ -43,9 +43,8 @@ gives the *schema* of the *impressions* table.  Doing a query is just as simple:
                                       30,014                                    4,491
 
 
-The CLI offers the following features over and above being a 'normal' Python REPL::
-
-* configurable command history
-* no *import* statements required to load Hustle functionality
-* auto-completion (with TAB key) of all Hustle functions, Tables, and Columns
-* query results (from :func:`select <hustle.select>` are automatically sent to *stdout*
+The CLI offers the following features over and above being a 'normal' Python REPL:
+- configurable command history
+- no *import* statements required to load Hustle functionality
+- auto-completion (with TAB key) of all Hustle functions, Tables, and Columns
+- query results (from :func:`select <hustle.select>` are automatically sent to *stdout*

--- a/doc/howto/configure.rst
+++ b/doc/howto/configure.rst
@@ -12,11 +12,11 @@ and has the following possible settings:
 ==============      ==============================      ==============================================
 Name                Default Value                       Description
 ==============      ==============================      ==============================================
-server:             disco://localhost                   The Disco master node
-worker_class:       hustle.core.pipeworker.Worker       The Disco Worker class
-dump:               False                               True will automatically print select() results
-nest:               False                               True will return a Table from select()
-partition:          16                                  The number of partitions for restrict-select
-history_size:       1000                                The number of history entries in the CLI
+server              disco://localhost                   The Disco master node
+worker_class        hustle.core.pipeworker.Worker       The Disco Worker class
+dump                False                               True will automatically print select() results
+nest                False                               True will return a Table from select()
+partition           16                                  The number of partitions for restrict-select
+history_size        1000                                The number of history entries in the CLI
 ==============      ==============================      ==============================================
 

--- a/doc/howto/query.rst
+++ b/doc/howto/query.rst
@@ -219,7 +219,7 @@ select() Return Values
 
 To facilitate a nice :ref:`cliguide` and to have usable results when *nesting* queries or just processing row oriented
 results of a 'normal' query, the :func:`select <hustle.select>` function will return a number of different results
-depending on it's parameters.
+depending on its parameters.
 
 * *nest=True* - will return a :class:`Table <hustle.Table>`
 * *dump=True* - this is the default in the CLI - will return None, but will dump the result to stdout
@@ -252,11 +252,11 @@ Also note that it is possible to iterate over all rows in a `Table <hustle.Table
 
 Non-blocking select()
 ---------------------
-If you want to run multiple queries at the same time, consider using non-blocking select - :func:`select_nb <hustle.select_nb>`. It's exactly the same as :func:`select <hustle.select>` except that it returns immediately after submitting query to the cluster. The user can use the return value - a :class:`Future <hustle.Future>` object to check the query's status and fetch its resutls.
+If you want to run multiple queries at the same time, consider passing `block=False` to `select. This causes `select` to return immediately after submitting query to the cluster. The user can use the return value - a :class:`Future <hustle.Future>` object to check the query's status and fetch its resutls.
 
 For example::
 
-    >>> future = select(imps.ad_id, imps.date, imps.cpm_millis, where=imps.date > '2014-01-15', nest=True)
+    >>> future = select(imps.ad_id, imps.date, imps.cpm_millis, where=imps.date > '2014-01-15', nest=True, block=False)
     >>> future.status()
     >>> 'active'
     ... run more queries here ...
@@ -273,5 +273,4 @@ For example::
 
 .. seealso::
 
-    :func:`hustle.select_nb`
     :class:`hustle.Future`

--- a/doc/howto/schema.rst
+++ b/doc/howto/schema.rst
@@ -5,43 +5,43 @@ Hustle Schema Design Guide
 
 Columns
 -------
-    The syntax for the *columns*  is a sequence of strings, where each string specifies a
-    column using the following syntax::
+The syntax for the *columns*  is a sequence of strings, where each string specifies a
+column using the following syntax::
 
-        [[wide] index][string | uint[8|16|32|64] | int[8|16|32|64] | trie[16|32] | lz4 | binary] column-name
+    [[wide] index][string | uint[8|16|32|64] | int[8|16|32|64] | trie[16|32] | lz4 | binary] column-name
 
-    ========        ==========      ========================================
-    Modifier        Sizes           Description
-    ========        ==========      ========================================
-    wide                            Use LRU cache when inserting this index
-    index                           Create index for this column
-    string                          String Type
-    bit                             1-bit integer / boolean type
-    uint            8 16 32 64      Unsigned Integer Type
-    int             8 16 32 64      Signed Integer Type
-    trie            16 32           Prefix Trie Compressed String type
-    lz4                             LZ4 Compressed String type
-    binary                          Unencoded, uncompressed string type
-    ========        ==========      ========================================
+========        ==========      ========================================
+Modifier        Sizes           Description
+========        ==========      ========================================
+wide                            Use LRU cache when inserting this index
+index                           Create index for this column
+string                          String Type
+bit                             1-bit integer / boolean type
+uint            8 16 32 64      Unsigned Integer Type
+int             8 16 32 64      Signed Integer Type
+trie            16 32           Prefix Trie Compressed String type
+lz4                             LZ4 Compressed String type
+binary                          Unencoded, uncompressed string type
+========        ==========      ========================================
 
 
-    If modifiers are omitted, the **DEFAULT** type is :code:`trie32` (un-indexed)
+If modifiers are omitted, the **DEFAULT** type is :code:`trie32` (un-indexed)
 
-    If sizes are omitted for :code:`uint int trie`, the **DEFAULT** is 32 bits
+If sizes are omitted for :code:`uint int trie`, the **DEFAULT** is 32 bits
 
-    Example::
+Example::
 
-        pixels = Table.create('pixels',
-              columns=['wide index string token', 'index uint8 isActive', 'index site_id', 'uint32 amount',
-                       'index int32 account_id', 'index city', 'index trie16 state', 'index int16 metro',
-                       'string ip', 'lz4 keyword', 'index string date'],
-              partition='date',
-              force=True)
+    pixels = Table.create('pixels',
+          columns=['wide index string token', 'index uint8 isActive', 'index site_id', 'uint32 amount',
+                   'index int32 account_id', 'index city', 'index trie16 state', 'index int16 metro',
+                   'string ip', 'lz4 keyword', 'index string date'],
+          partition='date',
+          force=True)
 
 Accessing Fields
 ----------------
 
-Consider the following code:
+Consider the following code::
 
     imps = Table.from_tag('impressions')
     select(imps.date, imps.site_id, where=imps)
@@ -53,7 +53,7 @@ Indexes
 -------
 By default, columns in Hustle are unindexed.  By indexing a column you make it available for use as a key in
 *where clause* and *join clauses* in the :func:`hustle.select` statement.  Unindexed columns can still
-be in the list of selected columns or in aggregation function.  The question whether to index a column or not is a
+be in the list of selected columns or in aggregation function.  The question of whether to index a column or not is a
 consideration of overall memory/disk space used by that column in your database.  An indexed column will take up
 to twice the amount of memory as an unindexed column.
 
@@ -113,9 +113,9 @@ Partitions
 Hustle employs a technique for splitting up data into distinct partitions based on a column in the target table.
 This allows us to significantly increase query performance by only considering the data that matches the partition
 specified in the query.  Typically a partition column has the following attributes:
-* the same column is in most Tables
-* the number of unique values for the column is low
-* the column is often in *where clauses*, often as ranges
+- the same column is in most Tables
+- the number of unique values for the column is low
+- the column is often in *where clauses*, often as ranges
 
 The DATE column usually fits the bill for the partition in most LOG type applications.
 


### PR DESCRIPTION
Mostly fixes to rst formatting.

`select_nb` appears to have been removed in favour of `select(block=False)`. I've updated the documentation to reflect this.
