### PR TITLE
Improved the build matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ matrix:
 before_install:
   - pushd .
   - travis_retry sudo apt-get update -qq
-  - if [[ $TRAVIS_PYTHON_VERSION != 'pypy' ]] ; then travis_retry pip install --install-option="--prefix=~/virtualenv/python$TRAVIS_PYTHON_VERSION" Cython fi
-  - if [[ $TRAVIS_PYTHON_VERSION == 'pypy' ]] ; then travis_retry pip install --install-option="--prefix=~/virtualenv/$TRAVIS_PYTHON_VERSION" Cython fi
+  - if [[ $TRAVIS_PYTHON_VERSION != 'pypy' ]] ; then travis_retry pip install --install-option="--prefix=~/virtualenv/python$TRAVIS_PYTHON_VERSION" Cython; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 'pypy' ]] ; then travis_retry pip install --install-option="--prefix=~/virtualenv/$TRAVIS_PYTHON_VERSION" Cython; fi
   - travis_retry sudo apt-get install -y curl erlang python-dev
   - travis_retry git clone https://github.com/discoproject/disco.git /tmp/disco
   - cd /tmp/disco && git checkout develop && sudo make install


### PR DESCRIPTION
Added travis_retry for all network operations and the suite will now run pypy (but will allow it to fail).
The problem is that you guys are using Cython instead of CFFI so PyPy might be slower than Python 2.7.
It is a start though.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/tspurway/hustle/57)

<!-- Reviewable:end -->
