### PR TITLE
Fix the order-by stage for binary aggregations

### DIFF
--- a/hustle/__init__.py
+++ b/hustle/__init__.py
@@ -708,7 +708,8 @@ def h_max(col):
         return Aggregation("max",
                            col,
                            f=lambda a, v: a if a > v else v,
-                           default=lambda: unichr(0x00))
+                           default=lambda: unichr(0x00),
+                           result_spec=Column('_max_type', type_indicator=mdb.MDB_STR))
 
 
 def h_min(col):
@@ -734,7 +735,8 @@ def h_min(col):
         return Aggregation("min",
                            col,
                            f=lambda a, v: a if a < v else v,
-                           default=lambda: unichr(0xFFFF))
+                           default=lambda: unichr(0xFFFF),
+                           result_spec=Column('_min_type', type_indicator=mdb.MDB_STR))
 
 
 def h_avg(col):

--- a/hustle/cardinality.py
+++ b/hustle/cardinality.py
@@ -1,9 +1,12 @@
-from hustle.core.marble import Aggregation
+from hustle.core.marble import Aggregation, Column
+
+import mdb
 
 
 def h_cardinality(col):
     """
     """
+
     def _inner_deault():
         from cardunion import Cardunion
         return Cardunion(12)
@@ -17,7 +20,8 @@ def h_cardinality(col):
                        f=_inner_hll_accumulate,
                        g=lambda a: a.count(),
                        h=lambda a: a.dumps(),
-                       default=_inner_deault)
+                       default=_inner_deault,
+                       result_spec=Column('_cardinality_type', type_indicator=mdb.MDB_UINT_32))
 
 
 def h_union(col):
@@ -34,7 +38,8 @@ def h_union(col):
                        f=_inner_hll_accumulate,
                        g=lambda a, c: a.dumps(),
                        h=lambda a: a.dumps(),
-                       default=_inner_deault)
+                       default=_inner_deault,
+                       result_spec=Column('_union_type', type_indicator=mdb.MDB_STR, compression_indicator=3))
 
 
 def h_minhash_merge(col):
@@ -52,4 +57,5 @@ def h_minhash_merge(col):
                        f=_inner_hll_accumulate,
                        g=lambda a, c: a.dumps(),
                        h=lambda a: a.dumps(),
-                       default=_inner_deault)
+                       default=_inner_deault,
+                       result_spec=Column('_minhash_merge_type', type_indicator=mdb.MDB_STR, compression_indicator=3))

--- a/hustle/core/marble.py
+++ b/hustle/core/marble.py
@@ -994,7 +994,7 @@ class Aggregation(object):
 
     def named(self, alias):
         newag = Aggregation(self.name, self.column.named(alias), self.f,
-                            self.g, self.h, self.default)
+                            self.g, self.h, self.default, self.result_spec)
         return newag
 
     def schema_string(self):

--- a/integration_test/setup.py
+++ b/integration_test/setup.py
@@ -1,8 +1,11 @@
 from hustle import Table, insert
 from hustle.core.settings import Settings, overrides
+import ujson
+
 
 IMPS = '__test_imps'
 PIXELS = '__test_pixels'
+PIXELS_HLL = '__test_pixels_hll'
 IPS = '__test_ips'
 
 
@@ -13,6 +16,65 @@ def imp_process(data):
     if host.startswith('www.'):
         host = host[4:]
     data['site_id'] = host
+
+
+def insert_hll(table, file=None, streams=None, preprocess=None,
+               maxsize=100 * 1024 * 1024, tmpdir='/tmp', decoder=ujson.decode,
+               lru_size=10000, hll_field=None, **kwargs):
+    from cardunion import Cardunion
+    import os
+
+    settings = Settings(**kwargs)
+    ddfs = settings['ddfs']
+
+    def part_tag(name, partition=None):
+        rval = "hustle:" + name
+        if partition:
+            rval += ':' + str(partition)
+        return rval
+
+    def hll_iter(strms):
+        buf = {}
+        fields = table._field_names
+        fields.remove('hll')
+        #  fields.remove('maxhash')
+
+        for stream in strms:
+            for line in stream:
+                try:
+                    data = decoder(line)
+                except Exception as e:
+                    print "Exception decoding record (skipping): %s %s" % (e, line)
+                else:
+                    if preprocess:
+                        if not preprocess(data):
+                            continue
+                    key = ujson.dumps([data[f] for f in fields])
+                    if key not in buf:
+                        hll = Cardunion(12)
+                        buf[key] = hll
+                    else:
+                        hll = buf[key]
+
+                    hll.add(data[hll_field])
+
+        for key, hll in buf.iteritems():
+            data = dict(zip(fields, ujson.loads(key)))
+            data['hll'] = hll.dumps()
+            yield data
+
+    if file:
+        streams = [open(file)]
+    lines, partition_files = table._insert([hll_iter(streams)],
+                                           maxsize=maxsize, tmpdir=tmpdir,
+                                           decoder=lambda x: x, lru_size=lru_size)
+    if partition_files is not None:
+        for part, pfile in partition_files.iteritems():
+            tag = part_tag(table._name, part)
+            ddfs.push(tag, [pfile])
+            print 'pushed %s, %s' % (part, tag)
+            os.unlink(pfile)
+    return table._name, lines
 
 
 def ensure_tables():
@@ -34,6 +96,12 @@ def ensure_tables():
                                    'index int16 metro', 'string ip', 'lz4 keyword', 'index string date'],
                           partition='date',
                           force=True)
+    pixel_hlls = Table.create(PIXELS_HLL,
+                              columns=['index bit isActive', 'index trie site_id', 'index int account_id',
+                                       'index trie city', 'index trie16 state', 'index string date',
+                                       'binary hll'],
+                              partition='date',
+                              force=True)
     ips = Table.create(IPS,
                        columns=['index trie16 exchange_id', 'index uint32 ip'],
                        force=True)
@@ -52,6 +120,11 @@ def ensure_tables():
     if len(tags) == 0:
         # insert the files
         insert(ips, File='fixtures/ip.json')
+
+    tags = ddfs.list("hustle:%s:" % PIXELS_HLL)
+    if len(tags) == 0:
+        # insert the files
+        insert_hll(pixel_hlls, file='./fixtures/pixel.json', hll_field='token')
 
 
 if __name__ == '__main__':

--- a/integration_test/test_cardinality.py
+++ b/integration_test/test_cardinality.py
@@ -1,0 +1,86 @@
+from hustle import select, Table
+from setup import PIXELS_HLL
+from hustle.core.settings import Settings, overrides
+from hustle.cardinality import h_cardinality as h_hll
+
+from collections import defaultdict
+from operator import itemgetter
+
+import unittest
+import ujson
+
+
+HLL_ESTIMATE_ERROR = .04
+
+
+class TestCardinalityQuery(unittest.TestCase):
+    def setUp(self):
+        overrides['server'] = 'disco://localhost'
+        overrides['dump'] = False
+        overrides['nest'] = False
+        self.settings = Settings()
+
+    def tearDown(self):
+        pass
+
+    def checkEstimate(self, estimate, expect):
+        self.assertAlmostEqual(estimate, expect,
+                               delta=int(HLL_ESTIMATE_ERROR * expect))
+
+    def test_cardinality_all(self):
+        hll = Table.from_tag(PIXELS_HLL)
+        res = select(h_hll(hll.hll), where=hll)
+        estimate = next(iter(res))[0]
+        tokens = set([])
+        with open("./fixtures/pixel.json") as f:
+            for line in f:
+                record = ujson.loads(line)
+                tokens.add(record["token"])
+        self.checkEstimate(estimate, len(tokens))
+        res.purge()
+
+    def test_cardinality_on_condition(self):
+        hll = Table.from_tag(PIXELS_HLL)
+        active_tokens = set([])
+        inactive_tokens = set([])
+        with open("./fixtures/pixel.json") as f:
+            for line in f:
+                record = ujson.loads(line)
+                if record["isActive"]:
+                    active_tokens.add(record["token"])
+                else:
+                    inactive_tokens.add(record["token"])
+        res = select(h_hll(hll.hll), where=(hll.isActive == 1))
+        estimate = next(iter(res))[0]
+        self.checkEstimate(estimate, len(active_tokens))
+        res.purge()
+
+        res = select(h_hll(hll.hll), where=(hll.isActive == 0))
+        estimate = next(iter(res))[0]
+        self.checkEstimate(estimate, len(inactive_tokens))
+        res.purge()
+
+    def test_cardinality_with_order_by(self):
+        hll = Table.from_tag(PIXELS_HLL)
+        tokens_by_date = defaultdict(set)
+        with open("./fixtures/pixel.json") as f:
+            for line in f:
+                record = ujson.loads(line)
+                tokens_by_date[record["date"]].add(record["token"])
+        result = [(date, len(tokens)) for date, tokens in tokens_by_date.items()]
+
+        # Test order by date
+        expects = sorted(result, key=itemgetter(0), reverse=True)
+        res = select(hll.date, h_hll(hll.hll), where=hll, order_by=0, desc=True)
+        estimates = list(res)
+        for i, (date, expected_cardinality) in enumerate(expects):
+            self.assertEqual(estimates[i][0], date)
+            self.checkEstimate(estimates[i][1], expected_cardinality)
+        res.purge()
+
+        # Test order by hll
+        res = select(hll.date, h_hll(hll.hll), where=hll, order_by=1, desc=True)
+        l = list(res)
+        for i in range(len(l) - 1):
+            self.assertTrue(l[i][1] >= l[i + 1][1])
+        res.purge()


### PR DESCRIPTION
This patch removes the last roadblock for landing the Hyperloglog feature in Hustle. The introduction of `binary` type and its aggregation functions (like `h_cardinality(hll)`) requires some changes in the Hustle pipeline work. 

All unit/integration tests passed. Some hll specific integration tests still missing, will fix that in a follow up patch.

@tspurway r?